### PR TITLE
wacom: Send custom keycodes when gestures are detected

### DIFF
--- a/drivers/input/touchscreen/wacom/wacom_i2c.c
+++ b/drivers/input/touchscreen/wacom/wacom_i2c.c
@@ -302,6 +302,11 @@ static void wacom_i2c_set_input_values(struct i2c_client *client,
 	__set_bit(KEY_UNKNOWN, input_dev->keybit);
 	__set_bit(KEY_PEN_PDCT, input_dev->keybit);
 	__set_bit(KEY_WAKEUP, input_dev->keybit);
+	__set_bit(KEY_PEN_UTD, input_dev->keybit);
+	__set_bit(KEY_PEN_DTU, input_dev->keybit);
+	__set_bit(KEY_PEN_RTL, input_dev->keybit);
+	__set_bit(KEY_PEN_LTR, input_dev->keybit);
+	__set_bit(KEY_PEN_LP, input_dev->keybit);
 #ifdef WACOM_USE_GAIN
 	__set_bit(ABS_DISTANCE, input_dev->absbit);
 #endif
@@ -566,6 +571,35 @@ static ssize_t epen_hand_store(struct device *dev,
 	return count;
 }
 #endif
+
+static ssize_t epen_gestures_show(struct device *dev,
+				  struct device_attribute *attr, char *buf)
+{
+	struct wacom_i2c *wac_i2c = dev_get_drvdata(dev);
+
+	dev_info(&wac_i2c->client->dev,
+			"%s: enabled_gestures=%d\n", __func__,
+			wac_i2c->enabled_gestures);
+
+	return sprintf(buf, "%d\n", wac_i2c->enabled_gestures);
+}
+
+static ssize_t epen_gestures_store(struct device *dev,
+				   struct device_attribute *attr, const char *buf,
+				   size_t count)
+{
+	struct wacom_i2c *wac_i2c = dev_get_drvdata(dev);
+	int val;
+
+	sscanf(buf, "%d", &val);
+
+	wac_i2c->enabled_gestures = val;
+
+	dev_info(&wac_i2c->client->dev,
+			"%s: enabled_gestures=%d\n", __func__, val);
+
+	return count;
+}
 
 static bool check_update_condition(struct wacom_i2c *wac_i2c, const char buf)
 {
@@ -1072,6 +1106,9 @@ static DEVICE_ATTR(boost_level,
 		   S_IWUSR | S_IWGRP, NULL, boost_level_store);
 #endif
 
+static DEVICE_ATTR(epen_gestures, S_IWUSR | S_IWGRP | S_IRUGO,
+		   epen_gestures_show, epen_gestures_store);
+
 static struct attribute *epen_attributes[] = {
 #ifdef USE_WACOM_BLOCK_KEYEVENT
 	&dev_attr_epen_delay_time.attr,
@@ -1104,6 +1141,7 @@ static struct attribute *epen_attributes[] = {
 #ifdef WACOM_BOOSTER
 	&dev_attr_boost_level.attr,
 #endif
+	&dev_attr_epen_gestures.attr,
 	NULL,
 };
 

--- a/drivers/input/touchscreen/wacom/wacom_i2c_func.c
+++ b/drivers/input/touchscreen/wacom/wacom_i2c_func.c
@@ -907,6 +907,30 @@ void wacom_i2c_softkey(struct wacom_i2c *wac_i2c, s16 key, s16 pressed)
 }
 #endif
 
+static void handle_gestures(int x, int y, ktime_t end, struct wacom_i2c *wac_i2c)
+{
+	int dx = x - wac_i2c->gesture_start_x;
+	int dy = y - wac_i2c->gesture_start_y;
+	int dt = ktime_to_ms(ktime_sub(end, wac_i2c->gesture_start_time));
+
+	if (abs(dy) > abs(dx)) {
+		if (abs(dy) > MIN_GEST_DIST) {
+			wac_i2c->gesture_key = dy < 0 ? KEY_PEN_DTU : KEY_PEN_UTD;
+			return;
+		}
+	} else {
+		if (abs(dx) > MIN_GEST_DIST) {
+			wac_i2c->gesture_key = dx < 0 ? KEY_PEN_RTL : KEY_PEN_LTR;
+			return;
+		}
+	}
+
+	if (dt >= LONG_PRESS_TIME) {
+		wac_i2c->gesture_key = KEY_PEN_LP;
+		return;
+	}
+}
+
 int wacom_i2c_coord(struct wacom_i2c *wac_i2c)
 {
 	bool prox = false;
@@ -1089,7 +1113,9 @@ int wacom_i2c_coord(struct wacom_i2c *wac_i2c)
 #endif
 			input_report_key(wac_i2c->input_dev,
 					 BTN_STYLUS, stylus);
-			input_report_key(wac_i2c->input_dev, BTN_TOUCH, prox);
+			if (!stylus && !wac_i2c->side_pressed) {
+				input_report_key(wac_i2c->input_dev, BTN_TOUCH, prox);
+			}
 			input_report_key(wac_i2c->input_dev, wac_i2c->tool, 1);
 /*
 #ifdef WACOM_PDCT_WORK_AROUND
@@ -1136,14 +1162,30 @@ int wacom_i2c_coord(struct wacom_i2c *wac_i2c)
 
 			wac_i2c->pen_pressed = prox;
 
-			if (stylus && !wac_i2c->side_pressed)
+			if (stylus && !wac_i2c->side_pressed) {
 				dev_info(&wac_i2c->client->dev,
 						"%s: side on\n",
 						__func__);
-			else if (!stylus && wac_i2c->side_pressed)
+				wac_i2c->gesture_key = -1;
+				wac_i2c->gesture_start_x = x;
+				wac_i2c->gesture_start_y = y;
+				wac_i2c->gesture_start_time = ktime_get();
+			} else if (!stylus && wac_i2c->side_pressed) {
 				dev_info(&wac_i2c->client->dev,
 						"%s: side off\n",
 						__func__);
+				handle_gestures(x, y, ktime_get(), wac_i2c);
+				if (wac_i2c->gesture_key > -1 &&
+						(wac_i2c->enabled_gestures &
+						(1 << (wac_i2c->gesture_key - 0x2f1)))) {
+					input_report_key(wac_i2c->input_dev,
+							wac_i2c->gesture_key, 1);
+					input_sync(wac_i2c->input_dev);
+					input_report_key(wac_i2c->input_dev,
+							wac_i2c->gesture_key, 0);
+					input_sync(wac_i2c->input_dev);
+				}
+			}
 
 			wac_i2c->side_pressed = stylus;
 		}

--- a/include/linux/input.h
+++ b/include/linux/input.h
@@ -821,6 +821,15 @@ struct input_keymap_entry {
 #define KEY_SIDE_TOUCH_7		0x2ef
 #define KEY_SIDE_CAMERA_DETECTED	0x2f0
 
+/*
+ * S-Pen Gestures
+ */
+#define KEY_PEN_DTU			0x2f1
+#define KEY_PEN_UTD			0x2f2
+#define KEY_PEN_RTL			0x2f3
+#define KEY_PEN_LTR			0x2f4
+#define KEY_PEN_LP			0x2f5
+
 /* We avoid low common keys in module aliases so they don't get huge. */
 #define KEY_MIN_INTERESTING	KEY_MUTE
 #define KEY_MAX			0x2ff

--- a/include/linux/wacom_i2c.h
+++ b/include/linux/wacom_i2c.h
@@ -215,6 +215,9 @@ struct wacom_g5_callbacks {
 	int (*check_prox)(struct wacom_g5_callbacks *);
 };
 
+#define LONG_PRESS_TIME 500
+#define MIN_GEST_DIST 384
+
 /*Parameters for i2c driver*/
 struct wacom_i2c {
 	struct i2c_client *client;
@@ -302,6 +305,12 @@ struct wacom_i2c {
 	bool touch_pressed;
 #endif
 	bool enabled;
+
+	int enabled_gestures;
+	int gesture_key;
+	int gesture_start_x;
+	int gesture_start_y;
+	ktime_t gesture_start_time;
 };
 
 struct wacom_g5_platform_data {


### PR DESCRIPTION
* Modeled after the old gesture handling code in fw/b
* This allows us to use device specific code to handle
  s-pen gestures instead of polluting fw/b
* Supports the following gestures:
 - Swipe right
 - Swipe left
 - Swipe down
 - Swipe up
 - Long press
* To trigger the gestures, press the button on
  the s-pen, execute the gesture action, and
  then release the side button of the s-pen
* This patch also blocks touch input from the
  s-pen when the stylus button is pressed, to
  avoid causing unintended touch input

Change-Id: I55651a36d147ba69e6dbd987d1a267f544570ba0
Signed-off-by: Paul Keith <javelinanddart@gmail.com>